### PR TITLE
Advert about papyrus display problems

### DIFF
--- a/Papyrus/README.adoc
+++ b/Papyrus/README.adoc
@@ -2,7 +2,7 @@
 
 First: https://github.com/oliviercailloux/UML/blob/master/Papyrus/Various.adoc#Install[install] Papyrus.
 
-WARNING: Some Eclipse Marketplace plugin won’t disable functionalities of your papyrus project (Example : with https://marketplace.eclipse.org/content/darkest-dark-theme-devstyle[Darkest Dark Theme with DevStyle], you might loose some arrows)
+WARNING: Some Eclipse Marketplace plugins can disable functionalities of your papyrus projects (Example : with https://marketplace.eclipse.org/content/darkest-dark-theme-devstyle[Darkest Dark Theme with DevStyle], you might loose some arrows)
 
 == Tutorials
 * https://github.com/oliviercailloux/UML/blob/master/Papyrus/Create.adoc[Create] a Papyrus model

--- a/Papyrus/README.adoc
+++ b/Papyrus/README.adoc
@@ -2,6 +2,8 @@
 
 First: https://github.com/oliviercailloux/UML/blob/master/Papyrus/Various.adoc#Install[install] Papyrus.
 
+WARNING: Some Eclipse Marketplace plugin won’t disable functionalities of your papyrus project (Example : with https://marketplace.eclipse.org/content/darkest-dark-theme-devstyle[Darkest Dark Theme with DevStyle], you might loose some arrows)
+
 == Tutorials
 * https://github.com/oliviercailloux/UML/blob/master/Papyrus/Create.adoc[Create] a Papyrus model
 * https://github.com/oliviercailloux/UML/blob/master/Papyrus/Use%20cases.adoc[Use cases]


### PR DESCRIPTION
Hello, 
After a big investigation in our project team, we found the reason of our papyrus arrow display problems. It comes from a *DevStyle* plugin called _[Darkest Dark Theme with DevStyle](https://marketplace.eclipse.org/content/darkest-dark-theme-devstyle)_.
In fact, the color changes done by this plugin affect papyrus diagrams style.